### PR TITLE
Handle empty query variables

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ window.a = require('graphql');
 
 export default class App extends Component {
   fetchData({query, variables}) {
-    return window.a.graphql(Schema, query, null, JSON.parse(variables));
+    return window.a.graphql(Schema, query, null, JSON.parse(variables || '{}'));
   }
 
   render() {


### PR DESCRIPTION
When testing the build of defining-mutations, queries no longer worked.  The console revealed the error: `Uncaught SyntaxError: Unexpected end of JSON input`.  After reviewing, this was because the default value for the query variables (the empty string) was being passed directly to `JSON.parse`.  While looking into this, I noticed that a simple fix was introduced for this in 07a5f14 on build-schema (which I've copied here) and that master also handles this case, but in a very different way.

There is a simple workaround of just typing `{}` into the query variables text box, but this is a simple solution to just make it work out of the box.
