### PR TITLE
fix path for index on windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',
-    './src/index'
+    path.join(__dirname, 'src', 'index')
   ],
   output: {
     path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Webpack was not building the scripts correctly because of the path to the index file.
